### PR TITLE
Adapt to new NLU API

### DIFF
--- a/snips_nlu_metrics/tests/mock_engine.py
+++ b/snips_nlu_metrics/tests/mock_engine.py
@@ -6,7 +6,10 @@ from snips_nlu_metrics import Engine
 def dummy_parsing_result(text):
     return {
         "input": text,
-        "intent": None,
+        "intent": {
+            "intentName": None,
+            "probability": 0.5
+        },
         "slots": []
     }
 

--- a/snips_nlu_metrics/utils/metrics_utils.py
+++ b/snips_nlu_metrics/utils/metrics_utils.py
@@ -116,6 +116,8 @@ def compute_engine_metrics(engine, test_utterances, intent_list,
 
         if parsing["intent"] is not None:
             predicted_intent = parsing["intent"]["intentName"]
+            if predicted_intent is None:
+                predicted_intent = NONE_INTENT_NAME
         else:
             # Use a string here to avoid having a None key in the metrics dict
             predicted_intent = NONE_INTENT_NAME


### PR DESCRIPTION
This PR adds support for a NLU parsing output of the following form, when no intent is detected:

```python
{
  "input": "foo bar",
  "intent": {
    "intentName": None,
    "probability": 0.552122
  },
  "slots": []
}
```

instead of the (still supported) format:
```python
{
  "input": "foo bar",
  "intent": None,
  "slots": None
}
```