### PR TITLE
Add out of domain test utterances in each cross validation split

### DIFF
--- a/snips_nlu_metrics/metrics.py
+++ b/snips_nlu_metrics/metrics.py
@@ -21,8 +21,8 @@ from snips_nlu_metrics.utils.metrics_utils import (
 def compute_cross_val_metrics(
         dataset, engine_class, nb_folds=5, train_size_ratio=1.0,
         drop_entities=False, include_slot_metrics=True,
-        slot_matching_lambda=None, out_of_domain_utterances=None,
-        progression_handler=None, num_workers=1, seed=None):
+        slot_matching_lambda=None, progression_handler=None, num_workers=1,
+        seed=None, out_of_domain_utterances=None):
     """Compute end-to-end metrics on the dataset using cross validation
 
     Args:
@@ -44,21 +44,22 @@ def compute_cross_val_metrics(
             `expected_slot` corresponds to the slot as defined in the dataset,
             and `actual_slot` corresponds to the slot as returned by the NLU
             default(None)
-        out_of_domain_utterances (list, optional): If defined, list of 
-            out-of-domain utterances to be added to the pool of test utterances 
-            in each split
         progression_handler (lambda, optional): handler called at each
             progression (%) step (default=None)
         num_workers (int, optional): number of workers to use. Each worker
             is assigned a certain number of splits (default=1)
         seed (int, optional): seed for the split creation
+        out_of_domain_utterances (list, optional): If defined, list of 
+            out-of-domain utterances to be added to the pool of test utterances 
+            in each split
 
     Returns:
         dict: Metrics results containing the following data
-
+    
             - "metrics": the computed metrics
             - "parsing_errors": the list of parsing errors
-
+            - "confusion_matrix": the computed confusion matrix
+            - "average_metrics": the metrics averaged over all intents    
     """
 
     if isinstance(dataset, basestring):
@@ -154,6 +155,8 @@ def compute_train_test_metrics(
 
             - "metrics": the computed metrics
             - "parsing_errors": the list of parsing errors
+            - "confusion_matrix": the computed confusion matrix
+            - "average_metrics": the metrics averaged over all intents
     """
 
     if isinstance(train_dataset, basestring):

--- a/snips_nlu_metrics/utils/metrics_utils.py
+++ b/snips_nlu_metrics/utils/metrics_utils.py
@@ -263,11 +263,6 @@ def compute_average_metrics(metrics, ignore_none_intent=True):
             intent: intent_metrics for intent, intent_metrics in
             iteritems(metrics) if intent and intent != NONE_INTENT_NAME
         }
-    else:
-        metrics = {
-            intent: intent_metrics for intent, intent_metrics in
-            iteritems(metrics)
-        }
 
     nb_intents = len(metrics)
     if not nb_intents:

--- a/snips_nlu_metrics/utils/metrics_utils.py
+++ b/snips_nlu_metrics/utils/metrics_utils.py
@@ -24,8 +24,8 @@ INITIAL_METRICS = {
 
 
 def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
-                                     drop_entities=False,
-                                     out_of_domain_utterances=None, seed=None):
+                                     drop_entities=False, seed=None,
+                                     out_of_domain_utterances=None):
     if train_size_ratio > 1.0 or train_size_ratio < 0:
         raise ValueError("Invalid value for train size ratio: %s"
                          % train_size_ratio)

--- a/snips_nlu_metrics/utils/metrics_utils.py
+++ b/snips_nlu_metrics/utils/metrics_utils.py
@@ -24,7 +24,8 @@ INITIAL_METRICS = {
 
 
 def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
-                                     drop_entities=False, seed=None):
+                                     drop_entities=False,
+                                     out_of_domain_utterances=None, seed=None):
     if train_size_ratio > 1.0 or train_size_ratio < 0:
         raise ValueError("Invalid value for train size ratio: %s"
                          % train_size_ratio)
@@ -72,6 +73,15 @@ def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
             splits.append((train_dataset, test_utterances))
     except ValueError:
         not_enough_data(n_splits, train_size_ratio)
+
+    if out_of_domain_utterances is not None:
+        additional_test_utterances = [
+            [NONE_INTENT_NAME, {DATA: [{TEXT: utterance}]}]
+            for utterance in out_of_domain_utterances
+        ]
+        for split in splits:
+            split[1].extend(additional_test_utterances)
+
     return splits
 
 
@@ -246,12 +256,19 @@ def add_count_metrics(lhs, rhs):
     }
 
 
-def compute_average_metrics(metrics):
+def compute_average_metrics(metrics, ignore_none_intent=True):
     metrics = deepcopy(metrics)
-    metrics = {
-        intent: intent_metrics for intent, intent_metrics in iteritems(metrics)
-        if intent and intent != NONE_INTENT_NAME
-    }
+    if ignore_none_intent:
+        metrics = {
+            intent: intent_metrics for intent, intent_metrics in
+            iteritems(metrics) if intent and intent != NONE_INTENT_NAME
+        }
+    else:
+        metrics = {
+            intent: intent_metrics for intent, intent_metrics in
+            iteritems(metrics)
+        }
+
     nb_intents = len(metrics)
     if not nb_intents:
         return None


### PR DESCRIPTION
Allows to pass a list of out-of-domain utterances to the split creation method in `compute_cross_val_metrics`. These utterances will be added to each test split with the label `None` and the final metrics will be also averaged over this None class.