### PR TITLE
Fix multiprocessing issue when non zero exit code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     "numpy>=1.7,<2.0",
     "scipy>=1.0,<2.0",
     "scikit-learn>=0.19,<0.20",
-    "pathos~=0.2"
+    "joblib>=0.13,<0.14"
 ]
 
 extras_require = {

--- a/snips_nlu_metrics/tests/mock_engine.py
+++ b/snips_nlu_metrics/tests/mock_engine.py
@@ -23,3 +23,15 @@ class MockEngine(Engine):
 
     def parse(self, text):
         return dummy_parsing_result(text)
+
+
+class MockEngineSegfault(Engine):
+    def __init__(self):
+        self.fitted = False
+
+    def fit(self, dataset):
+        self.fitted = True
+
+    def parse(self, text):
+        # Simulate a segmentation fault
+        exit(139)

--- a/snips_nlu_metrics/tests/test_metrics.py
+++ b/snips_nlu_metrics/tests/test_metrics.py
@@ -1,16 +1,28 @@
 import io
 import json
+import logging
 import os
+import sys
 import unittest
 
 from snips_nlu_metrics.metrics import (compute_cross_val_metrics,
                                        compute_train_test_metrics)
 from snips_nlu_metrics.tests.mock_engine import MockEngine
-from snips_nlu_metrics.utils.constants import METRICS, PARSING_ERRORS, \
-    CONFUSION_MATRIX, AVERAGE_METRICS
+from snips_nlu_metrics.utils.constants import (
+    METRICS, PARSING_ERRORS, CONFUSION_MATRIX, AVERAGE_METRICS)
 
 
 class TestMetrics(unittest.TestCase):
+    def setUp(self):
+        logger = logging.getLogger("snips_nlu_metrics")
+        formatter = logging.Formatter(
+            '%(asctime)s - %(levelname)s - %(message)s')
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
     def test_compute_cross_val_metrics(self):
         # Given
         dataset_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),

--- a/snips_nlu_metrics/tests/test_metrics.py
+++ b/snips_nlu_metrics/tests/test_metrics.py
@@ -7,7 +7,7 @@ import unittest
 
 from snips_nlu_metrics.metrics import (compute_cross_val_metrics,
                                        compute_train_test_metrics)
-from snips_nlu_metrics.tests.mock_engine import MockEngine
+from snips_nlu_metrics.tests.mock_engine import MockEngine, MockEngineSegfault
 from snips_nlu_metrics.utils.constants import (
     METRICS, PARSING_ERRORS, CONFUSION_MATRIX, AVERAGE_METRICS)
 
@@ -107,7 +107,81 @@ class TestMetrics(unittest.TestCase):
 
         self.assertDictEqual(expected_metrics, res["metrics"])
 
-        # Testing parallel CV with various number of workers
+    def test_compute_cross_val_metrics_with_multiple_workers(self):
+        # Given
+        dataset_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                    "resources", "beverage_dataset.json")
+        with io.open(dataset_path, encoding="utf8") as f:
+            dataset = json.load(f)
+
+        # When/Then
+        expected_metrics = {
+            "null": {
+                "intent": {
+                    "true_positive": 0,
+                    "false_positive": 11,
+                    "false_negative": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0
+                },
+                "exact_parsings": 0,
+                "slots": {},
+                "intent_utterances": 0
+            },
+            "MakeCoffee": {
+                "intent": {
+                    "true_positive": 0,
+                    "false_positive": 0,
+                    "false_negative": 7,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0
+                },
+                "exact_parsings": 0,
+                "slots": {
+                    "number_of_cups": {
+                        "true_positive": 0,
+                        "false_positive": 0,
+                        "false_negative": 0,
+                        "precision": 0.0,
+                        "recall": 0.0,
+                        "f1": 0.0
+                    }
+                },
+                "intent_utterances": 7
+            },
+            "MakeTea": {
+                "intent": {
+                    "true_positive": 0,
+                    "false_positive": 0,
+                    "false_negative": 4,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0
+                },
+                "exact_parsings": 0,
+                "slots": {
+                    "number_of_cups": {
+                        "true_positive": 0,
+                        "false_positive": 0,
+                        "false_negative": 0,
+                        "precision": 0.0,
+                        "recall": 0.0,
+                        "f1": 0.0
+                    },
+                    "beverage_temperature": {
+                        "true_positive": 0,
+                        "false_positive": 0,
+                        "false_negative": 0,
+                        "precision": 0.0,
+                        "recall": 0.0,
+                        "f1": 0.0
+                    }
+                },
+                "intent_utterances": 4
+            }
+        }
         try:
             res = compute_cross_val_metrics(
                 dataset=dataset, engine_class=MockEngine, nb_folds=2,
@@ -116,13 +190,18 @@ class TestMetrics(unittest.TestCase):
             self.fail(e.args[0])
         self.assertDictEqual(expected_metrics, res["metrics"])
 
-        try:
-            res = compute_cross_val_metrics(
-                dataset=dataset, engine_class=MockEngine, nb_folds=2,
-                num_workers=2)
-        except Exception as e:
-            self.fail(e.args[0])
-        self.assertDictEqual(expected_metrics, res["metrics"])
+    def test_should_raise_when_non_zero_exit(self):
+        # Given
+        dataset_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                    "resources", "beverage_dataset.json")
+        with io.open(dataset_path, encoding="utf8") as f:
+            dataset = json.load(f)
+
+        # When/Then
+        with self.assertRaises(SystemExit):
+            compute_cross_val_metrics(
+                dataset=dataset, engine_class=MockEngineSegfault, nb_folds=4,
+                num_workers=4)
 
     def test_compute_cross_val_metrics_without_slot_metrics(self):
         # Given

--- a/snips_nlu_metrics/tests/test_metrics_utils.py
+++ b/snips_nlu_metrics/tests/test_metrics_utils.py
@@ -310,7 +310,6 @@ class TestMetricsUtils(unittest.TestCase):
 
     def test_should_compute_utterance_metrics_when_correct_intent(self):
         # Given
-        text = "this is intent1 with slot1_value and slot2_value"
         actual_intent = "intent1"
         actual_slots = [
             {
@@ -372,7 +371,6 @@ class TestMetricsUtils(unittest.TestCase):
 
     def test_should_exclude_slot_metrics_when_specified(self):
         # Given
-        text = "this is intent1 with slot1_value and slot2_value"
         actual_intent = "intent1"
         actual_slots = [
             {
@@ -420,7 +418,6 @@ class TestMetricsUtils(unittest.TestCase):
 
     def test_should_use_slot_matching_lambda_to_compute_metrics(self):
         # Given
-        text = "this is intent1 with slot1_value and slot2_value"
         actual_intent = "intent1"
         actual_slots = [
             {

--- a/snips_nlu_metrics/utils/metrics_utils.py
+++ b/snips_nlu_metrics/utils/metrics_utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import logging
 from copy import deepcopy
 
 import numpy as np
@@ -16,6 +17,8 @@ from snips_nlu_metrics.utils.dataset_utils import (
     update_entities_with_utterances)
 from snips_nlu_metrics.utils.exception import NotEnoughDataError
 
+logger = logging.getLogger(__name__)
+
 INITIAL_METRICS = {
     TRUE_POSITIVE: 0,
     FALSE_POSITIVE: 0,
@@ -27,15 +30,15 @@ def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
                                      drop_entities=False, seed=None,
                                      out_of_domain_utterances=None):
     if train_size_ratio > 1.0 or train_size_ratio < 0:
-        raise ValueError("Invalid value for train size ratio: %s"
-                         % train_size_ratio)
+        error_msg = "Invalid value for train size ratio: %s" % train_size_ratio
+        logger.exception(error_msg)
+        raise ValueError(error_msg)
 
     nb_utterances = {intent: len(data[UTTERANCES])
                      for intent, data in iteritems(dataset[INTENTS])}
     total_utterances = sum(itervalues(nb_utterances))
     if total_utterances < n_splits:
-        raise NotEnoughDataError("Number of utterances is too low (%s)"
-                                 % total_utterances)
+        not_enough_data(dataset, n_splits, train_size_ratio, nb_utterances)
     if drop_entities:
         dataset = deepcopy(dataset)
         for entity, data in iteritems(dataset[ENTITIES]):
@@ -62,7 +65,7 @@ def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
             test_utterances = utterances[test_index].tolist()
 
             if len(train_utterances) == 0:
-                not_enough_data(n_splits, train_size_ratio)
+                not_enough_data(dataset, n_splits, train_size_ratio)
             train_dataset = deepcopy(dataset)
             train_dataset[INTENTS] = dict()
             for intent_name, utterance in train_utterances:
@@ -72,7 +75,7 @@ def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
                     deepcopy(utterance))
             splits.append((train_dataset, test_utterances))
     except ValueError:
-        not_enough_data(n_splits, train_size_ratio)
+        not_enough_data(dataset, n_splits, train_size_ratio)
 
     if out_of_domain_utterances is not None:
         additional_test_utterances = [
@@ -85,11 +88,19 @@ def create_shuffle_stratified_splits(dataset, n_splits, train_size_ratio=1.0,
     return splits
 
 
-def not_enough_data(n_splits, train_size_ratio):
-    raise NotEnoughDataError("Not enough data given the other "
-                             "parameters "
-                             "(nb_folds=%s, train_size_ratio=%s)"
-                             % (n_splits, train_size_ratio))
+def not_enough_data(dataset, n_splits, train_size_ratio,
+                    nb_utterances=None):
+    if nb_utterances is None:
+        nb_utterances = {intent: len(data[UTTERANCES])
+                         for intent, data in iteritems(dataset[INTENTS])}
+    total_utterances = sum(itervalues(nb_utterances))
+    error_msg = "Not enough data: total_utterances={t}, nb_folds={f}, " \
+                "train_size_ratio={r}.".format(t=total_utterances, f=n_splits,
+                                               r=train_size_ratio)
+    error_msg += " Intents details: "
+    error_msg += ", ".join("%s -> %d utterances" % (intent, nb)
+                           for intent, nb in iteritems(nb_utterances))
+    raise NotEnoughDataError(error_msg)
 
 
 def compute_split_metrics(engine_class, split, intent_list,

--- a/snips_nlu_metrics/utils/metrics_utils.py
+++ b/snips_nlu_metrics/utils/metrics_utils.py
@@ -387,9 +387,5 @@ def format_expected_output(intent_name, utterance, include_slots):
     return expected_output
 
 
-def is_builtin_entity(entity_name):
-    return entity_name.startswith("snips/")
-
-
 def exact_match(lhs_slot, rhs_slot):
     return lhs_slot[TEXT] == rhs_slot["rawValue"]


### PR DESCRIPTION
**Description**
This PR fixes an issue when using several workers to compute the metrics, and one of the jobs return a non-zero exit code. In such cases, the computation would hang as `pathos`, the multiprocessing lib used, does not handle properly non-zero exit codes.