### PR TITLE
Leverage batch prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Use the `batch_parse` method of the engine class when implemented to speedup inference [#120](https://github.com/snipsco/snips-nlu-metrics/pull/120)
+
 ## [0.14.5] - 2019-08-20
 ### Fixed
 - Fix issue with intents filter when dataset has not enough data [#118](https://github.com/snipsco/snips-nlu-metrics/pull/118)
@@ -56,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - Samples
 
 
+[Unreleased]: https://github.com/snipsco/snips-nlu-metrics/compare/0.14.5...HEAD
 [0.14.5]: https://github.com/snipsco/snips-nlu-metrics/compare/0.14.4...0.14.5
 [0.14.4]: https://github.com/snipsco/snips-nlu-metrics/compare/0.14.3...0.14.4
 [0.14.3]: https://github.com/snipsco/snips-nlu-metrics/compare/0.14.2...0.14.3
@@ -63,4 +68,4 @@ All notable changes to this project will be documented in this file.
 [0.14.1]: https://github.com/snipsco/snips-nlu-metrics/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/snipsco/snips-nlu-metrics/compare/0.13.0...0.14.0
 [0.13.0]: https://github.com/snipsco/snips-nlu-metrics/compare/0.12.0...0.13.0
-[0.12.0]: https://github.com/snipsco/snips-nlu-metrics/compare/0.11.1...0.12.0
+[0.12.0]: https://github.com/snipsco/snips-nlu-metrics/compare/0.11.1...0.12.0@

--- a/snips_nlu_metrics/tests/mock_engine.py
+++ b/snips_nlu_metrics/tests/mock_engine.py
@@ -45,6 +45,11 @@ class KeyWordMatchingEngine(Engine):
         return dummy_parsing_result(text, intent)
 
 
+class BatchKeyWordMatchingEngine(KeyWordMatchingEngine):
+    def batch_parse(self, texts, intents_filter=None):
+        return [self.parse(t, intents_filter=intents_filter) for t in texts]
+
+
 class MockEngineSegfault(Engine):
     def __init__(self):
         self.fitted = False

--- a/snips_nlu_metrics/tests/test_metrics.py
+++ b/snips_nlu_metrics/tests/test_metrics.py
@@ -8,7 +8,8 @@ import unittest
 from snips_nlu_metrics.metrics import (compute_cross_val_metrics,
                                        compute_train_test_metrics)
 from snips_nlu_metrics.tests.mock_engine import (
-    MockEngine, MockEngineSegfault, KeyWordMatchingEngine)
+    MockEngine, MockEngineSegfault, KeyWordMatchingEngine,
+    BatchKeyWordMatchingEngine)
 from snips_nlu_metrics.utils.constants import (
     METRICS, PARSING_ERRORS, CONFUSION_MATRIX, AVERAGE_METRICS)
 
@@ -118,52 +119,52 @@ class TestMetrics(unittest.TestCase):
             dataset = json.load(f)
 
         # When/Then
+        for cls in [KeyWordMatchingEngine, BatchKeyWordMatchingEngine]:
+            res = compute_cross_val_metrics(
+                dataset=dataset, engine_class=cls,
+                nb_folds=2, intents_filter=["intent2", "intent3"],
+                include_slot_metrics=False, seed=42)
 
-        res = compute_cross_val_metrics(
-            dataset=dataset, engine_class=KeyWordMatchingEngine,
-            nb_folds=2, intents_filter=["intent2", "intent3"],
-            include_slot_metrics=False, seed=42)
+            expected_metrics = {
+                "null": {
+                    "intent": {
+                        "true_positive": 0,
+                        "false_positive": 2,
+                        "false_negative": 0,
+                        "precision": 0.0,
+                        "recall": 0.0,
+                        "f1": 0.0
+                    },
+                    "exact_parsings": 0,
+                    "intent_utterances": 0
+                },
+                "intent2": {
+                    "intent": {
+                        "true_positive": 3,
+                        "false_positive": 0,
+                        "false_negative": 1,
+                        "precision": 1.0,
+                        "recall": 3. / 4.,
+                        "f1": 0.8571428571428571
+                    },
+                    "exact_parsings": 3,
+                    "intent_utterances": 4
+                },
+                "intent3": {
+                    "intent": {
+                        "true_positive": 2,
+                        "false_positive": 0,
+                        "false_negative": 1,
+                        "precision": 1.0,
+                        "recall": 2. / 3.,
+                        "f1": 0.8
+                    },
+                    "exact_parsings": 2,
+                    "intent_utterances": 3
+                },
+            }
 
-        expected_metrics = {
-            "null": {
-                "intent": {
-                    "true_positive": 0,
-                    "false_positive": 2,
-                    "false_negative": 0,
-                    "precision": 0.0,
-                    "recall": 0.0,
-                    "f1": 0.0
-                },
-                "exact_parsings": 0,
-                "intent_utterances": 0
-            },
-            "intent2": {
-                "intent": {
-                    "true_positive": 3,
-                    "false_positive": 0,
-                    "false_negative": 1,
-                    "precision": 1.0,
-                    "recall": 3. / 4.,
-                    "f1": 0.8571428571428571
-                },
-                "exact_parsings": 3,
-                "intent_utterances": 4
-            },
-            "intent3": {
-                "intent": {
-                    "true_positive": 2,
-                    "false_positive": 0,
-                    "false_negative": 1,
-                    "precision": 1.0,
-                    "recall": 2. / 3.,
-                    "f1": 0.8
-                },
-                "exact_parsings": 2,
-                "intent_utterances": 3
-            },
-        }
-
-        self.assertDictEqual(expected_metrics, res["metrics"])
+            self.assertDictEqual(expected_metrics, res["metrics"])
 
     def test_compute_cross_val_metrics_with_multiple_workers(self):
         # Given


### PR DESCRIPTION
Use the `batch_parse` method of the engine class when implemented instead of the `parse` method.

For some engine classes leveraging batch prediction can speed up the metrics a lot. For instance when your engine is just calling a API that support batch prediction, you're doing a single call for all `test_utterances` instead of `len(test_utterances)` calls.

